### PR TITLE
only run tests on python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,11 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
-          - "3.10"
           - "3.11"
-          - "3.12"
-          - "3.13"
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
avoid the api too many requests error, only test on python 3.11